### PR TITLE
Change Discord navbar link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,7 +119,7 @@ const config = {
             position: 'right',
           },
           {
-            href: 'https://github.com/dlpnd/nvr-wiki',
+            href: 'https://discord.com/invite/QgN6mR6eTK',
             label: 'Discord',
             position: 'right',
           },


### PR DESCRIPTION
Navbar link for Discord currently redirects to GitHub. This should hopefully change that.