### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dlpnd/nvr-wiki/security/code-scanning/3](https://github.com/dlpnd/nvr-wiki/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow (e.g., fetching files, deploying to GitHub Pages), the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `pages: write` for deploying to GitHub Pages.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as no job-specific permissions are defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
